### PR TITLE
Modified configs for finetune GR00T by phosphobot on script (not on GUI)

### DIFF
--- a/gr00t/experiment/data_config.py
+++ b/gr00t/experiment/data_config.py
@@ -1348,8 +1348,29 @@ class ConfigGeneratorFromNames(BaseDataConfig):
     Will name action keys as the given parameters
     """
 
-    def __init__(self, video_keys: list[str], state_keys: list[str], action_keys: list[str]):
+    # def __init__(self, video_keys: list[str], state_keys: list[str], action_keys: list[str]):
+    #     super().__init__()
+
+    #     self.video_keys = video_keys
+    #     self.state_keys = state_keys
+    #     self.action_keys = action_keys
+
+    #     self.language_keys = ["annotation.human.task_description"]
+
+    #     self.observation_indices = [0]
+    #     self.action_indices = list(range(16))
+
+    def __init__(
+            self, 
+            num_arms: int, 
+            num_cams: int, 
+            video_keys: list[str],
+            state_keys: list[str],
+            action_keys: list[str]
+    ):
         super().__init__()
+        self.num_arms = num_arms
+        self.num_cams = num_cams
 
         self.video_keys = video_keys
         self.state_keys = state_keys

--- a/scripts/gr00t_finetune.py
+++ b/scripts/gr00t_finetune.py
@@ -79,13 +79,13 @@ class Config:
     tune_llm: bool = False
     """Whether to fine-tune the language model backbone."""
 
-    tune_visual: bool = True
+    tune_visual: bool = False # True
     """Whether to fine-tune the vision tower."""
 
     tune_projector: bool = True
     """Whether to fine-tune the projector."""
 
-    tune_diffusion_model: bool = True
+    tune_diffusion_model: bool = False #True
     """Whether to fine-tune the diffusion model."""
 
     resume: bool = False
@@ -165,8 +165,11 @@ def main(config: Config):
     # ------------ step 1: load dataset ------------
     embodiment_tag = EmbodimentTag(config.embodiment_tag)
 
-    # 1.1 modality configs and transforms
-    data_config_cls = ConfigGenerator(num_arms=config.num_arms, num_cams=config.num_cams)
+    # # 1.1 modality configs and transforms
+    data_config_cls = ConfigGenerator(num_arms=config.num_arms, num_cams=config.num_cams,
+                                      video_keys=config.video_keys, state_keys=config.state_keys, 
+                                      action_keys = config.action_keys,
+                                      )
     modality_configs = data_config_cls.modality_config()
     transforms = data_config_cls.transform()
 
@@ -285,6 +288,11 @@ def main(config: Config):
 if __name__ == "__main__":
     # Parse arguments using tyro
     config = tyro.cli(Config)
+
+    # SO100のを追加
+    config.video_keys = ["video.image_cam_0", "video.image_cam_1"]
+    config.state_keys = ["state.arm_0"]
+    config.action_keys = ["action.arm_0"]
 
     # Print the tyro config
     print("\n" + "=" * 50)

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -17,7 +17,6 @@ from gr00t.eval.robot import RobotInferenceServer  # type: ignore
 from gr00t.experiment.data_config import ConfigGenerator  # type: ignore
 from gr00t.model.policy import Gr00tPolicy  # type: ignore
 
-model_path = "PLB/GR00T-N1-so100-wc"  # Change this to your model path
 
 # Open your trained model and check the experiment_cfg/metadata.json file
 
@@ -25,13 +24,16 @@ model_path = "PLB/GR00T-N1-so100-wc"  # Change this to your model path
 embodiment_tag = "new_embodiment"  # Change this to your embodiment tag, in most cases it will just be "new_embodiment"
 
 # Please fill with the number of arms and cameras used to train the model
+
+model_path = "hiroyukikaneko/gr00t_initial_ft2"
 data_config = ConfigGenerator(
-   num_arms=1,
-   num_cams=2,
-   video_keys=["video.cam_context", "video.cam_wrist"],
-   state_keys = ["state.single_arm", "state.gripper"],
-   action_keys = ["action.single_arm", "action.gripper"]
-)
+  num_arms=1, 
+  num_cams=2, 
+  video_keys= ["video.image_cam_0", "video.image_cam_1"], #["video.cam_context", "video.cam_wrist"],
+  state_keys = ["state.arm_0"], #["state.single_arm", "state.gripper"],
+  action_keys = ["action.arm_0"] #["action.single_arm", "action.gripper"])
+ )
+
 
 
 args = Namespace(


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes [#26](https://github.com/jdsc/robotics-research/issues/26)
の内容を反映

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- SO100のkey情報を入力
- phosphobot側のTrainコードから直接渡せないパラメータを直接変更
   - OOM回避のためvisual, diffusionのTuningをFalseに変更）

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
